### PR TITLE
high_level: Fix pid variable type

### DIFF
--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -101,7 +101,7 @@ pub struct Event {
     pub fd: i32,
     pub path: String,
     pub events: Vec<FanEvent>,
-    pub pid: u32,
+    pub pid: i32,
 }
 
 impl From<fanotify_event_metadata> for Event {
@@ -111,7 +111,7 @@ impl From<fanotify_event_metadata> for Event {
             fd: metadata.fd,
             path: path.to_str().unwrap().to_string(),
             events: events_from_mask(metadata.mask),
-            pid: metadata.pid as u32,
+            pid: metadata.pid as i32,
         }
     }
 }
@@ -183,7 +183,7 @@ impl Fanotify {
                 fd: metadata.fd,
                 path: String::from(path),
                 events: events_from_mask(metadata.mask),
-                pid: metadata.pid as u32,
+                pid: metadata.pid as i32,
             });
             close_fd(metadata.fd);
         }


### PR DESCRIPTION
pid_t is defined as a signed integer in the Linux kernel:

https://elixir.bootlin.com/linux/latest/source/tools/include/nolibc/nolibc.h#L132

As well as in Rust libraries like:

https://docs.rs/libc/0.2.65/libc/type.pid_t.html

To keep the compatibility with those, change the type of pid to i32.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>