### PR TITLE
Fix demo, widen FanotifyPath impl, auto-null terminate strings, AsFd …

### DIFF
--- a/demo/with_poll/Cargo.toml
+++ b/demo/with_poll/Cargo.toml
@@ -8,6 +8,6 @@ description = "fanotify-rs with poll"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.3"
-fanotify-rs = { git = "https://github.com/n01e0/fanotify-rs" }
-nix = "0.19.0"
+clap = "4.4.18"
+fanotify-rs = { path = "../../" }
+nix = {version = "0.27.1", features = ["poll"] }

--- a/demo/with_poll/src/main.rs
+++ b/demo/with_poll/src/main.rs
@@ -1,29 +1,25 @@
-#[macro_use]
-extern crate clap;
-extern crate fanotify;
-extern crate nix;
-
+use std::os::fd::AsFd;
 use fanotify::high_level::*;
 use nix::poll::{poll, PollFd, PollFlags};
 
 fn main() {
-    let app = clap_app!(fanotify_demo =>
-        (version:       crate_version!())
-        (author:        crate_authors!())
-        (about:         crate_description!())
-        (@arg path: +required "watch target mount point")
-    )
-    .get_matches();
+    let app = clap::Command::new("with_poll")
+        .arg(
+            clap::Arg::new("path").index(1).required(true)
+        )
+        .get_matches();
 
     let fd = Fanotify::new_with_nonblocking(FanotifyMode::CONTENT);
-    fd.add_mountpoint(FAN_OPEN_EXEC | FAN_CLOSE_WRITE, app.value_of("path").unwrap()).unwrap();
+    fd.add_mountpoint(FAN_OPEN_EXEC | FAN_CLOSE_WRITE, app.get_one::<String>("path").unwrap()).unwrap();
 
-    let mut fds = [PollFd::new(fd.as_raw_fd(), PollFlags::POLLIN)];
+    let fd_handle = fd.as_fd();
+    let mut fds = [PollFd::new(&fd_handle, PollFlags::POLLIN)];
     loop {
         let poll_num = poll(&mut fds, -1).unwrap();
         if poll_num > 0 {
             for event in fd.read_event() {
                 println!("{:#?}", event);
+                fd.send_response(event.fd, FanotifyResponse::Allow);
             }
         } else {
             eprintln!("poll_num <= 0!");

--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -3,6 +3,7 @@ use crate::FanotifyPath;
 use enum_iterator::IntoEnumIterator;
 use std::fs::read_link;
 use std::io::Error;
+use std::os::fd::{AsFd, BorrowedFd};
 
 pub use crate::low_level::{
     FAN_ACCESS, FAN_ACCESS_PERM, FAN_ATTRIB, FAN_CLOSE, FAN_CLOSE_NOWRITE, FAN_CLOSE_WRITE,
@@ -13,6 +14,12 @@ pub use crate::low_level::{
 
 pub struct Fanotify {
     fd: i32,
+}
+
+impl AsFd for Fanotify {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.fd)}
+    }
 }
 
 impl<T> From<T> for Fanotify

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ impl FanotifyPath for str {
     }
 }
 
-impl FanotifyPath for String {
+impl<T: AsRef<std::ffi::OsStr>> FanotifyPath for T {
     fn as_os_str(&self) -> &std::ffi::OsStr {
-        std::ffi::OsStr::new(self.as_str())
+        self.as_ref()
     }
 }

--- a/src/low_level.rs
+++ b/src/low_level.rs
@@ -350,17 +350,16 @@ pub fn fanotify_mark<P: ?Sized + FanotifyPath>(
     path: &P,
 ) -> Result<(), Error> {
     unsafe {
+        let mut raw_path = path.as_os_str().as_bytes().to_vec();
+        raw_path.push(0u8); // data must be null terminated
+
+        // Path is a c-string, so must be null terminated
         match libc::fanotify_mark(
             fanotify_fd,
             flags,
             mask,
             dirfd,
-            path.as_os_str()
-                .as_bytes()
-                .iter()
-                .map(|p| *p as i8)
-                .collect::<Vec<i8>>()
-                .as_ptr(),
+            raw_path.as_ptr() as *const i8,
         ) {
             0 => {
                 return Ok(());


### PR DESCRIPTION
…borrows for Fanotify

The demo now replies to fanotify events, preventing file events from hanging forever.

`FanotifyPath` now auto-implements for all `AsRef<OsStr>`.

`fanotify_mark` now pushes a null byte to the end of the path, to ensure c-string compatibility.

`Fanotify` now implements `AsFd` for the new API on `PollFd`. The polling example has also been update to reflect this.